### PR TITLE
Fix issue with ZIP files with over 32767 entries

### DIFF
--- a/zip_file/src/com/google/android/vending/expansion/zipfile/ZipResourceFile.java
+++ b/zip_file/src/com/google/android/vending/expansion/zipfile/ZipResourceFile.java
@@ -342,7 +342,8 @@ public class ZipResourceFile {
          * archive. After that, we can release our EOCD hunt buffer.
          */
 
-        int numEntries = bbuf.getShort(eocdIdx + kEOCDNumEntries);
+        // "numEntries" is a 16-bit _unsigned_ value so make it a "char"
+        char numEntries = (char) bbuf.getShort(eocdIdx + kEOCDNumEntries);
         long dirSize = bbuf.getInt(eocdIdx + kEOCDSize) & 0xffffffffL;
         long dirOffset = bbuf.getInt(eocdIdx + kEOCDFileOffset) & 0xffffffffL;
 


### PR DESCRIPTION
The number of entries in the ZIP archive is a 16-bit unsigned value but was being treated as signed meaning archives with more than 32767 entries were unreadable.  Fixed by using the only unsigned 16-bit type Java offers which is char instead of int.